### PR TITLE
fix: eslint unicorn/no-unsafe-string-replacement 対応

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,10 @@ async function main() {
   const path = process.env.GWB_PATH ?? ''
   const query = process.env.GWB_QUERY ?? '?url={url}'
 
-  const url = `${baseUrl}${path}${query}`.replace('{url}', discordWebhookUrl)
+  const url = `${baseUrl}${path}${query}`.replace(
+    '{url}',
+    () => discordWebhookUrl
+  )
 
   const baseUrlOrigin = new URL(baseUrl).origin
   const knownOrigins = new Set(


### PR DESCRIPTION
## 概要

`@book000/eslint-config` の更新 (#1463) で有効化された ESLint ルール `unicorn/no-unsafe-string-replacement` に対応します。

## 内容

`src/main.ts` の `` `${baseUrl}${path}${query}`.replace('{url}', discordWebhookUrl)`` は置換値 (`discordWebhookUrl`) がリテラルではなく、`$&` や `$1` などの特殊置換パターンとして解釈されうるため、`unicorn/no-unsafe-string-replacement` に抵触していました。関数形式のリプレーサー (`() => discordWebhookUrl`) を使うことで、置換値が特殊パターンとして解釈されないようにしています。

## 動作確認

- `pnpm run lint` (eslint + prettier + tsc) がローカルで成功することを確認
- `@book000/eslint-config` を `1.15.44` (#1463 相当) に上げた状態でも `pnpm run lint` が成功することを確認済み
